### PR TITLE
Modernize package specifications and version handling

### DIFF
--- a/mdx2/__init__.py
+++ b/mdx2/__init__.py
@@ -1,9 +1,3 @@
-import pkg_resources
+from importlib.metadata import version
 
-
-def getVersionNumber():
-    version = pkg_resources.require("mdx2")[0].version
-    return version
-
-
-__version__ = getVersionNumber()
+__version__ = version("mdx2")

--- a/mdx2/command_line/version.py
+++ b/mdx2/command_line/version.py
@@ -15,7 +15,7 @@ parser = argparse.ArgumentParser(
 
 def run(args=None):
     args = parser.parse_args(args)
-    print("mdx2:", mdx2.getVersionNumber())
+    print("mdx2:", mdx2.__version__)
     print("Python {0.major}.{0.minor}.{0.micro}".format(sys.version_info))
     print(f"Installed in: {os.path.split(mdx2.__file__)[0]}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,46 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mdx2"
+dynamic = ["version"]
+readme = "README.md"
+license = { text = "MIT" }
+authors = [
+    { email = "spm82@cornell.edu", name = "Steve Meisburger" },
+]
+requires-python = ">= 3.9"
+dependencies = [
+    "numpy",
+    "pandas",
+    "scipy",
+    "dxtbx",  # needs to be installed with conda
+    "nexusformat",
+    "joblib",
+    "numexpr",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=6.0"]
+
+[project.urls]
+repository = "https://github.com/diff-use/mdx2"
+
+[project.scripts]
+"mdx2.version" = "mdx2.command_line.version:run"
+"mdx2.import_data" = "mdx2.command_line.import_data:run"
+"mdx2.import_geometry" = "mdx2.command_line.import_geometry:run"
+"mdx2.find_peaks" = "mdx2.command_line.find_peaks:run"
+"mdx2.mask_peaks" = "mdx2.command_line.mask_peaks:run"
+"mdx2.tree" = "mdx2.command_line.tree:run"
+"mdx2.bin_image_series" = "mdx2.command_line.bin_image_series:run"
+"mdx2.integrate" = "mdx2.command_line.integrate:run"
+"mdx2.correct" = "mdx2.command_line.correct:run"
+"mdx2.merge" = "mdx2.command_line.merge:run"
+"mdx2.map" = "mdx2.command_line.map:run"
+"mdx2.scale" = "mdx2.command_line.scale:run"
+
 [tool.ruff]
 line-length = 120
 indent-width = 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,8 @@ docstring-code-line-length = "dynamic"
 [tool.ruff.lint]
 select = ["E", "F", "W", "A", "PLC", "PLE", "PLW", "I"]
 ignore = ["E741", "F541"]
+
+[tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -42,8 +42,8 @@ repository = "https://github.com/diff-use/mdx2"
 "mdx2.map" = "mdx2.command_line.map:run"
 "mdx2.scale" = "mdx2.command_line.scale:run"
 
-[tool.setuptools_scm]
-version_file = "mdx2/VERSION"
+[tool.setuptools.dynamic]
+version = {file = "mdx2/VERSION"}
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,12 @@ dependencies = [
     "numpy",
     "pandas",
     "scipy",
-    "dxtbx",  # needs to be installed with conda
+    "dxtbx", 
     "nexusformat",
     "joblib",
     "numexpr",
 ]
+# dxtbx needs to be installed with conda
 
 [project.optional-dependencies]
 test = ["pytest>=6.0"]
@@ -40,6 +41,9 @@ repository = "https://github.com/diff-use/mdx2"
 "mdx2.merge" = "mdx2.command_line.merge:run"
 "mdx2.map" = "mdx2.command_line.map:run"
 "mdx2.scale" = "mdx2.command_line.scale:run"
+
+[tool.setuptools_scm]
+version_file = "mdx2/VERSION"
 
 [tool.ruff]
 line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,4 @@
-import sys
-
-sys.stderr.write(
-    """
-===============================
-Unsupported installation method
-===============================
-mdx2 does not support installation with `python setup.py install`.
-Please use `python -m pip install .` instead.
-"""
-)
-sys.exit(1)
-
-
-# The below code will never execute, however GitHub is particularly
-# picky about where it finds Python packaging metadata.
-# See: https://github.com/github/feedback/discussions/6456
-#
-# To be removed once GitHub catches up.
+from setuptools import setup
 
 setup(  # noqa
     name="mdx2",

--- a/setup.py
+++ b/setup.py
@@ -1,57 +1,24 @@
-from setuptools import find_packages, setup
+import sys
+
+sys.stderr.write(
+    """
+===============================
+Unsupported installation method
+===============================
+mdx2 does not support installation with `python setup.py install`.
+Please use `python -m pip install .` instead.
+"""
+)
+sys.exit(1)
 
 
-# Get version number
-def getVersionNumber():
-    with open("mdx2/VERSION", "r") as vfile:
-        version = vfile.read().strip()
-    return version
+# The below code will never execute, however GitHub is particularly
+# picky about where it finds Python packaging metadata.
+# See: https://github.com/github/feedback/discussions/6456
+#
+# To be removed once GitHub catches up.
 
-
-__version__ = getVersionNumber()
-
-with open("README.md") as f:
-    readme = f.read()
-
-with open("LICENSE") as f:
-    license_file = f.read()
-
-setup(
+setup(  # noqa
     name="mdx2",
-    version=__version__,
-    description="mdx2: macromolecular diffuse scattering data reduction in python",
-    long_description=readme,
-    author="Steve P. Meisburger",
-    author_email="spm82@cornell.edu",
-    url="https://github.com/ando-lab/mdx2",
-    license=license_file,
-    packages=find_packages(exclude=("tests", "docs")),
-    python_requires=">=3.9",
-    install_requires=[
-        "numpy",
-        "pandas",
-        "scipy",
-        "dxtbx",  # needs to be installed with conda
-        "nexusformat",
-        "joblib",
-        "numexpr",
-    ],
-    tests_require=["pytest"],
-    entry_points={
-        "console_scripts": [
-            "mdx2.version=mdx2.command_line.version:run",
-            "mdx2.import_data=mdx2.command_line.import_data:run",
-            "mdx2.import_geometry=mdx2.command_line.import_geometry:run",
-            "mdx2.find_peaks=mdx2.command_line.find_peaks:run",
-            "mdx2.mask_peaks=mdx2.command_line.mask_peaks:run",
-            "mdx2.tree=mdx2.command_line.tree:run",
-            "mdx2.bin_image_series=mdx2.command_line.bin_image_series:run",
-            "mdx2.integrate=mdx2.command_line.integrate:run",
-            "mdx2.correct=mdx2.command_line.correct:run",
-            "mdx2.merge=mdx2.command_line.merge:run",
-            "mdx2.map=mdx2.command_line.map:run",
-            "mdx2.scale=mdx2.command_line.scale:run",
-        ],
-    },
-    include_package_data=True,
+    install_requires=[],
 )

--- a/setup.py
+++ b/setup.py
@@ -7,49 +7,51 @@ def getVersionNumber():
         version = vfile.read().strip()
     return version
 
+
 __version__ = getVersionNumber()
 
-with open('README.md') as f:
+with open("README.md") as f:
     readme = f.read()
 
-with open('LICENSE') as f:
+with open("LICENSE") as f:
     license_file = f.read()
 
 setup(
-    name='mdx2',
+    name="mdx2",
     version=__version__,
-    description='mdx2: macromolecular diffuse scattering data reduction in python',
+    description="mdx2: macromolecular diffuse scattering data reduction in python",
     long_description=readme,
-    author='Steve P. Meisburger',
-    author_email='spm82@cornell.edu',
-    url='https://github.com/ando-lab/mdx2',
+    author="Steve P. Meisburger",
+    author_email="spm82@cornell.edu",
+    url="https://github.com/ando-lab/mdx2",
     license=license_file,
-    packages=find_packages(exclude=('tests', 'docs')),
+    packages=find_packages(exclude=("tests", "docs")),
     python_requires=">=3.9",
     install_requires=[
         "numpy",
         "pandas",
         "scipy",
-        "dxtbx", # needs to be installed with conda
+        "dxtbx",  # needs to be installed with conda
         "nexusformat",
         "joblib",
         "numexpr",
     ],
+    tests_require=["pytest"],
     entry_points={
-        'console_scripts': [
-            'mdx2.version=mdx2.command_line.version:run',
-            'mdx2.import_data=mdx2.command_line.import_data:run',
-            'mdx2.import_geometry=mdx2.command_line.import_geometry:run',
-            'mdx2.find_peaks=mdx2.command_line.find_peaks:run',
-            'mdx2.mask_peaks=mdx2.command_line.mask_peaks:run',
-            'mdx2.tree=mdx2.command_line.tree:run',
-            'mdx2.bin_image_series=mdx2.command_line.bin_image_series:run',
-            'mdx2.integrate=mdx2.command_line.integrate:run',
-            'mdx2.correct=mdx2.command_line.correct:run',
-            'mdx2.merge=mdx2.command_line.merge:run',
-            'mdx2.map=mdx2.command_line.map:run',
-            'mdx2.scale=mdx2.command_line.scale:run',
-            ],
+        "console_scripts": [
+            "mdx2.version=mdx2.command_line.version:run",
+            "mdx2.import_data=mdx2.command_line.import_data:run",
+            "mdx2.import_geometry=mdx2.command_line.import_geometry:run",
+            "mdx2.find_peaks=mdx2.command_line.find_peaks:run",
+            "mdx2.mask_peaks=mdx2.command_line.mask_peaks:run",
+            "mdx2.tree=mdx2.command_line.tree:run",
+            "mdx2.bin_image_series=mdx2.command_line.bin_image_series:run",
+            "mdx2.integrate=mdx2.command_line.integrate:run",
+            "mdx2.correct=mdx2.command_line.correct:run",
+            "mdx2.merge=mdx2.command_line.merge:run",
+            "mdx2.map=mdx2.command_line.map:run",
+            "mdx2.scale=mdx2.command_line.scale:run",
+        ],
     },
     include_package_data=True,
 )

--- a/tests/test_version_number.py
+++ b/tests/test_version_number.py
@@ -1,0 +1,12 @@
+import re
+
+from mdx2 import getVersionNumber
+
+
+def test_version_number():
+    """version string returned by getVersionNumber should match symver semantics"""
+    version_string = getVersionNumber()
+    semver_regex = r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"  # noqa: E501
+    match = re.match(semver_regex, version_string)
+    assert match
+    major, minor, patch, prerelease, buildmetadata = match.groups()

--- a/tests/test_version_number.py
+++ b/tests/test_version_number.py
@@ -1,12 +1,11 @@
 import re
 
-from mdx2 import getVersionNumber
+from mdx2 import __version__ as mdx2_version
 
 
-def test_version_number():
-    """version string returned by getVersionNumber should match symver semantics"""
-    version_string = getVersionNumber()
+def test_mdx2_version_number():
+    """check that mdx2.__version__ matches semver semantics"""
     semver_regex = r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"  # noqa: E501
-    match = re.match(semver_regex, version_string)
+    match = re.match(semver_regex, mdx2_version)
     assert match
     major, minor, patch, prerelease, buildmetadata = match.groups()


### PR DESCRIPTION
A minimal set of changes to resolve issue #15 and #16. 
1. Fully migrated packaging from `setup.py` to `pyproject.toml`. 
2. Created test to verify that installed version matches correct semantics (thank you stack overflow!)
3. Removed the unnecessary `getVersionNumber()`
4. Use more modern `importlib.metadata` instead of deprecating `pkg_resources`

Notes for the future:
- For now, the version number comes from the file `mdx2/VERSION`. In future, we should probably switch to a git-based dynamic versioning backend, like setuptools-scm.
- I retained a minimal setup.py in case it's needed for metadata by GitHub, but pip will run fine without it.