### PR TITLE
Add GitHub Actions workflow for Docker build and push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,38 @@
+name: docker
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Determine Docker tags
+        id: tags
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "tags=${{ vars.DOCKERHUB_USERNAME }}/mdx2:latest" >> $GITHUB_OUTPUT
+          else
+            echo "tags=${{ vars.DOCKERHUB_USERNAME }}/mdx2:test" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}


### PR DESCRIPTION
## Summary
Adds GitHub Actions workflow to build and push Docker images to Docker Hub.

## Changes
- Creates `.github/workflows/docker.yml`
- Triggers on push to main branch and on pull requests
- Main branch builds push `:latest` tag
- PR builds push `:test` tag
- Uses `DOCKERHUB_USERNAME` var and `DOCKERHUB_TOKEN` secret

## Test plan
- [ ] Verify workflow runs successfully on this PR (should push :test tag)
- [ ] Verify workflow runs successfully on main after merge (should push :latest tag)