### PR TITLE
Add JupyterHub singleuser support and VS Code proxy

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -27,6 +27,9 @@ COPY . .
 
 # Install the local package in editable mode within the environment
 RUN /usr/local/bin/micromamba run -n mdx2-dev pip install -e .
+RUN /usr/local/bin/micromamba run -n mdx2-dev pip install --no-cache-dir jupyterhub jupyter-vscode-proxy
 
 EXPOSE 8888
+
+CMD ["/usr/local/bin/micromamba", "run", "-n", "mdx2-dev", "jupyterhub-singleuser"]
 


### PR DESCRIPTION
## Summary
- Add `jupyterhub` and `jupyter-vscode-proxy` packages to the Docker image
- Add default CMD for `jupyterhub-singleuser`
- Skipped jovyan user creation (KubeSpawner handles UID mapping)

## Test plan
- [ ] `docker build .` succeeds
- [ ] `docker run -p 8888:8888` starts JupyterLab with VS Code button
- [ ] Verify image works as JupyterHub singleuser server