### PR TITLE
Add nproc argument in serial methods, with warning

### DIFF
--- a/mdx2/command_line/correct.py
+++ b/mdx2/command_line/correct.py
@@ -25,6 +25,7 @@ class Parameters:
     polarization: bool = True  # apply polarization correction
     lorentz: bool = False  # apply Lorentz correction
     p1: bool = False  # map Miller indices to asymmetric unit for P1 (Friedel symmetry only)
+    nproc: int = 1  # number of parallel processes (or 1 for sequential, -1 for all CPUs, -N for all but N+1)
     outfile: str = "corrected.nxs"  # name of the output NeXus file
 
 
@@ -39,6 +40,9 @@ def run_correct(params):
     efficiency = params.efficiency
     polarization = params.polarization
     lorentz = params.lorentz
+
+    if params.nproc != 1:
+        logger.info("Warning: serial execution only, ignoring nproc value")
 
     logger.info("Loading integrated data and geometry...")
     T = loadobj(hkl, "hkl_table")

--- a/mdx2/command_line/import_geometry.py
+++ b/mdx2/command_line/import_geometry.py
@@ -20,6 +20,8 @@ class Parameters:
     expt: str = field(positional=True)  # dials experiments file, such as refined.expt
     sample_spacing: Tuple[int, int, int] = (1, 10, 10)  # interval in degrees or pixels (phi, iy, ix)
     outfile: str = "geometry.nxs"  # name of the output NeXus file
+    nproc: int = 1  # number of parallel processes (or 1 for sequential, -1 for all CPUs, -N for all but N+1)
+
 
     def __post_init__(self):
         """Validate sample_spacing parameter"""
@@ -34,6 +36,9 @@ def run_import_geometry(params):
     spacing_phi_px = tuple(params.sample_spacing)
     spacing_px = spacing_phi_px[1:]
     outfile = params.outfile
+
+    if params.nproc != 1:
+        logger.info("Warning: serial execution only, ignoring nproc value")
 
     logger.info("Computing miller index lookup grid...")
     miller_index = geom.MillerIndex.from_expt(

--- a/mdx2/command_line/map.py
+++ b/mdx2/command_line/map.py
@@ -26,6 +26,7 @@ class Parameters:
     """limits for the hkl grid (hmin, hmax, kmin, kmax, lmin, lmax)"""
     signal: str = "intensity"  # column in hkl_table to map
     outfile: str = "map.nxs"  # name of the output NeXus file
+    nproc: int = 1  # number of parallel processes (or 1 for sequential, -1 for all CPUs, -N for all but N+1)
 
     def __post_init__(self):
         """Validate limits parameter"""
@@ -49,6 +50,9 @@ def run_map(params):
     apply_symmetry = params.symmetry
     signal = params.signal
     hmin, hmax, kmin, kmax, lmin, lmax = params.limits
+
+    if params.nproc != 1:
+        logger.info("Warning: serial execution only, ignoring nproc value")
 
     logger.info("Loading HKL table and geometry...")
     T = loadobj(hkl, "hkl_table")

--- a/mdx2/command_line/merge.py
+++ b/mdx2/command_line/merge.py
@@ -33,6 +33,8 @@ class Parameters:
     offset: bool = field(default=True, negative_prefix="--no-")  # apply offset model if present
     absorption: bool = field(default=True, negative_prefix="--no-")  # apply absorption model if present
     detector: bool = field(default=True, negative_prefix="--no-")  # apply detector model if present
+    nproc: int = 1  # number of parallel processes (or 1 for sequential, -1 for all CPUs, -N for all but N+1)
+
 
     def __post_init__(self):
         """Validate inter-parameter dependencies and outlier parameter"""
@@ -84,6 +86,9 @@ def run_merge(params):
     apply_detector = params.detector
     geometry = params.geometry
 
+    if params.nproc != 1:
+        logger.info("Warning: serial execution only, ignoring nproc value")
+ 
     # load data into a giant table
     logger.info("Loading {} HKL table(s)...", len(hkl))
     tabs = []

--- a/mdx2/command_line/scale.py
+++ b/mdx2/command_line/scale.py
@@ -27,6 +27,7 @@ class PrescaleParameters:
     offset: bool = False  # include offset model in pre-scaling refinement if offset.enable is True
     detector: bool = False  # include detector model in pre-scaling refinement if detector.enable is True
     absorption: bool = True  # include absorption model in pre-scaling refinement if absorption.enable is True
+    nproc: int = 1  # number of parallel processes (or 1 for sequential, -1 for all CPUs, -N for all but N+1)
 
 
 @dataclass
@@ -318,6 +319,9 @@ def run_scale(params):
     S = load_data_for_scaling(*params.hkl)
 
     MR = BatchModelRefiner(S)
+
+    if params.nproc != 1:
+        logger.info("Warning: serial execution only, ignoring nproc value")
 
     if params.scaling.enable:
         MR.add_scaling_models(


### PR DESCRIPTION
Add nproc argument in serial methods, with warning about serial execution when nproc != 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Added process count (`nproc`) parameter to command-line operations for parallelism configuration. The current implementation supports serial-only execution; specification of any non-default process count will trigger an informational warning message and the setting will be ignored. All existing functionality, computational behavior, and output formats remain completely unaffected by this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->